### PR TITLE
Can't put a <p> inside a <p>

### DIFF
--- a/src/preview/components/pricing/three-tiers-with-icons.tsx
+++ b/src/preview/components/pricing/three-tiers-with-icons.tsx
@@ -88,7 +88,7 @@ const PricingCard = ({ title, price, icon, features }: PricingCardProps) => {
         <chakra.h2 fontSize="2xl" fontWeight="bold">
           {title}
         </chakra.h2>
-        <Text fontSize="7xl" fontWeight="bold">
+        <Box fontSize="7xl" fontWeight="bold">
           <Text as="sup" fontSize="3xl" fontWeight="normal" top="-1em">
             $
           </Text>


### PR DESCRIPTION
Hey i got an hydratation error while using your exemple. 
`<p>` can't be inside `<p>`

A fix would be to use a `<Box>` or use the as property in the text : `<Text as='div' ... /> `

Btw love your template, it is useful for me ! 